### PR TITLE
Reduce number of runtime allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ name = "libzeropool-setup"
 required-features = ["cli_libzeropool_setup"] 
 
 [dependencies]
-fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.3", features = ["rand_support"] }
+fawkes-crypto = { path = "../fawkes-crypto/fawkes-crypto", features = ["rand_support"] }
 
 sha3 = "0.9.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0"}
 lazy_static = "1.4.0"
-chacha20poly1305 = "0.8.0"
+chacha20poly1305 = { version = "0.8.0", features = ["heapless"] }
 clap={ package = "clap-v3", version = "3.0.0-beta.1", optional=true}
 convert_case = "0.4.0"
 
@@ -36,4 +36,4 @@ cli_libzeropool_setup = ["clap", "fawkes-crypto/rand_support", "fawkes-crypto/ba
 default=["cli_libzeropool_setup", "in3out127"]
 
 [dev-dependencies]
-fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.3", features = ["rand_support", "backend_bellman_groth16"] }
+fawkes-crypto = { path = "../fawkes-crypto/fawkes-crypto", features = ["rand_support", "backend_bellman_groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "libzeropool-setup"
 required-features = ["cli_libzeropool_setup"] 
 
 [dependencies]
-fawkes-crypto = { path = "../fawkes-crypto/fawkes-crypto", features = ["rand_support"] }
+fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.3", features = ["rand_support"] }
 
 sha3 = "0.9.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -36,4 +36,4 @@ cli_libzeropool_setup = ["clap", "fawkes-crypto/rand_support", "fawkes-crypto/ba
 default=["cli_libzeropool_setup", "in3out127"]
 
 [dev-dependencies]
-fawkes-crypto = { path = "../fawkes-crypto/fawkes-crypto", features = ["rand_support", "backend_bellman_groth16"] }
+fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.3", features = ["rand_support", "backend_bellman_groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzeropool"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Igor Gulamov <igor.gulamov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -18,8 +18,6 @@ pub const POOLID_SIZE_BITS: usize = 24;
 pub const POLY_1305_TAG_SIZE: usize = 16;
 pub const U256_SIZE: usize = 32;
 
-pub const PREALLOC_DECRYPT_BUFFER_SIZE: usize = 64;
-
 pub fn num_size_bits<Fp:PrimeFieldParams+Sized>() -> usize {
     Fp::Inner::NUM_WORDS*Fp::Inner::WORD_BITS
 }

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -16,7 +16,9 @@ pub const SALT_SIZE_BITS: usize = 80;
 pub const POOLID_SIZE_BITS: usize = 24;
 
 pub const POLY_1305_TAG_SIZE: usize = 16;
-pub const U256_SIZE:usize = 32;
+pub const U256_SIZE: usize = 32;
+
+pub const PREALLOC_DECRYPT_BUFFER_SIZE: usize = 64;
 
 pub fn num_size_bits<Fp:PrimeFieldParams+Sized>() -> usize {
     Fp::Inner::NUM_WORDS*Fp::Inner::WORD_BITS

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -33,3 +33,13 @@ pub fn account_size_bits<Fp:PrimeFieldParams>() -> usize {
 
 //fist 12 bytes from keccak256("ZeroPool")
 pub const ENCRYPTION_NONCE: [u8;12] = [0x5b, 0xbd, 0xff, 0xc6, 0xfe, 0x73, 0xc4, 0x60, 0xf1, 0xb2, 0xb8, 0x5d];
+
+/// Size of prealloced buffer for shared secrets decryption.
+/// It's enough for shared secrets with 10 or less keys.
+pub const SHARED_SECRETS_HEAPLESS_SIZE: usize = 32 * 10 + 16;
+/// Size of prealloced buffer for account decryption.
+/// 86 bytes is an account size for bls12-381, buffer needs 16-bytes overhead for auth tag.
+pub const ACCOUNT_HEAPLESS_SIZE: usize = 86 + 16;
+/// Size of prealloced buffer for note decryption.
+/// 76 bytes is a note size for bls12-381, buffer needs 16-bytes overhead for auth tag.
+pub const NOTE_HEAPLESS_SIZE: usize = 76 + 16;

--- a/src/native/cipher.rs
+++ b/src/native/cipher.rs
@@ -11,7 +11,7 @@ use crate::{
         params::PoolParams,
         key::{derive_key_a, derive_key_p_d}
     },
-    constants::{self}
+    constants::{self, SHARED_SECRETS_HEAPLESS_SIZE, ACCOUNT_HEAPLESS_SIZE, NOTE_HEAPLESS_SIZE}
 };
 
 use sha3::{Digest, Keccak256};
@@ -19,6 +19,21 @@ use sha3::{Digest, Keccak256};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce, aead::AeadMutInPlace};
 use chacha20poly1305::aead::{Aead, NewAead};
 use chacha20poly1305::aead::heapless::Vec as HeaplessVec;
+
+/// Wrapper for HeaplessVec (if buffer size is less or equals to N) or Vec otherwise
+enum Buffer<T, const N: usize> {
+    HeapBuffer(Vec<T>),
+    HeaplessBuffer(HeaplessVec<T, N>)
+}
+
+impl<T, const N: usize> Buffer<T, N> {
+    fn as_slice(&self) -> &[T] {
+        match self {
+            Self::HeapBuffer(vec) => vec.as_slice(),
+            Self::HeaplessBuffer(heapless_vec) => heapless_vec.as_slice()
+        }
+    }
+}
 
 fn keccak256(data:&[u8])->[u8;constants::U256_SIZE] {
     let mut hasher = Keccak256::new();
@@ -36,58 +51,20 @@ fn symcipher_encode(key:&[u8], data:&[u8])->Vec<u8> {
     cipher.encrypt(nonce, data.as_ref()).unwrap()
 }
 
-//key stricly assumed to be unique for all messages. Using this function with multiple messages and one key is insecure!
-fn symcipher_decode(key: &[u8], data: &[u8]) -> Option<Vec<u8>> {
-    assert!(key.len()==constants::U256_SIZE);
-    let nonce = Nonce::from_slice(&constants::ENCRYPTION_NONCE);
-    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
-    cipher.decrypt(nonce, data).ok()
-}
-
-//key stricly assumed to be unique for all messages. Using this function with multiple messages and one key is insecure!
-fn symcipher_decode_in_place<const N: usize>(key: &[u8], ciphertext: &[u8]) -> Option<HeaplessVec<u8, N>> {
+/// Decrypts message in place if `ciphertext.len()` is less or equals to N, otherwise allocates memory in heap.
+/// Key stricly assumed to be unique for all messages. Using this function with multiple messages and one key is insecure!
+fn symcipher_decode<const N: usize>(key: &[u8], ciphertext: &[u8]) -> Option<Buffer<u8, N>> {
     assert!(key.len()==constants::U256_SIZE);
     let nonce = Nonce::from_slice(&constants::ENCRYPTION_NONCE);
     let mut cipher = ChaCha20Poly1305::new(Key::from_slice(key));
-    let mut buffer = HeaplessVec::<u8, N>::from_slice(ciphertext).ok()?;
-    cipher.decrypt_in_place(nonce, b"", &mut buffer).ok()?;
-    Some(buffer)
-}
 
-fn decrypt_note<P: PoolParams>(key: &[u8], ciphertext: &[u8]) -> Option<Note<P::Fr>> {
-    // 76 bytes is a note size for bls12-381, buffer needs 16-bytes overhead for auth tag
-    const NOTE_BUFFER_SIZE: usize = 76 + 16;
-    if ciphertext.len() <= NOTE_BUFFER_SIZE {
-        let plain = symcipher_decode_in_place::<NOTE_BUFFER_SIZE>(key, ciphertext)?;
-        Some(Note::try_from_slice(&plain).ok()?)
+    if ciphertext.len() <= N {
+        let mut buffer = HeaplessVec::<u8, N>::from_slice(ciphertext).ok()?;
+        cipher.decrypt_in_place(nonce, b"", &mut buffer).ok()?;
+        Some(Buffer::HeaplessBuffer(buffer))
     } else {
-        let plain = symcipher_decode(key, ciphertext)?;
-        Some(Note::try_from_slice(&plain).ok()?)
-    }
-}
-
-fn decrypt_account<P: PoolParams>(key: &[u8], ciphertext: &[u8]) -> Option<Account<P::Fr>> {
-    // 86 bytes is an account size for bls12-381, buffer needs 16-bytes overhead for auth tag
-    const ACCOUNT_BUFFER_SIZE: usize = 86 + 16;
-    if ciphertext.len() <= ACCOUNT_BUFFER_SIZE {
-        let plain = symcipher_decode_in_place::<ACCOUNT_BUFFER_SIZE>(key, ciphertext)?;
-        Some(Account::try_from_slice(&plain).ok()?)
-    } else {
-        let plain = symcipher_decode(key, ciphertext)?;
-        Some(Account::try_from_slice(&plain).ok()?)
-    }
-}
-
-fn decrypt_shared_secrets(key: &[u8], ciphertext: &[u8]) -> Option<Vec<u8>> {
-    // It's suitable for most transactions
-    const SHARED_SECRETS_BUFFER_SIZE: usize = 32 * 10 + 16;
-    if ciphertext.len() <= SHARED_SECRETS_BUFFER_SIZE {
-        let plain = symcipher_decode_in_place::<SHARED_SECRETS_BUFFER_SIZE>(key, ciphertext)?;
-        // It's still should be better in our case because it doesn't allocate memory when decryption failed
-        Some(plain.to_vec())
-    } else {
-        let plain = symcipher_decode(key, ciphertext)?;
-        Some(plain)
+        let plain = cipher.decrypt(nonce, ciphertext).ok()?;
+        Some(Buffer::HeapBuffer(plain))
     }
 }
 
@@ -190,15 +167,16 @@ pub fn decrypt_out<P: PoolParams>(eta:Num<P::Fr>, mut memo:&[u8], params:&P)->Op
             keccak256(&x)
         };
         let ciphertext = buf_take(&mut memo, shared_secret_ciphertext_size)?;
-        decrypt_shared_secrets(&key, ciphertext)?
+        symcipher_decode::<SHARED_SECRETS_HEAPLESS_SIZE>(&key, ciphertext)?
     };
-    let mut shared_secret_text_ptr =&shared_secret_text[..];
+    let mut shared_secret_text_ptr = shared_secret_text.as_slice();
 
     let account_key= <[u8;constants::U256_SIZE]>::deserialize(&mut shared_secret_text_ptr).ok()?;
     let note_key = (0..nozero_notes_num).map(|_| <[u8;constants::U256_SIZE]>::deserialize(&mut shared_secret_text_ptr)).collect::<Result<Vec<_>,_>>().ok()?;
 
     let account_ciphertext = buf_take(&mut memo, account_size+constants::POLY_1305_TAG_SIZE)?;
-    let account = decrypt_account::<P>(&account_key, account_ciphertext)?;
+    let account_plain = symcipher_decode::<ACCOUNT_HEAPLESS_SIZE>(&account_key, account_ciphertext)?;
+    let account = Account::try_from_slice(account_plain.as_slice()).ok()?;
 
     if account.hash(params)!= account_hash {
         return None;
@@ -207,7 +185,8 @@ pub fn decrypt_out<P: PoolParams>(eta:Num<P::Fr>, mut memo:&[u8], params:&P)->Op
     let note = (0..nozero_notes_num).map(|i| {
         buf_take(&mut memo, num_size)?;
         let ciphertext = buf_take(&mut memo, note_size+constants::POLY_1305_TAG_SIZE)?;
-        let note = decrypt_note::<P>(&note_key[i], ciphertext)?;
+        let plain = symcipher_decode::<NOTE_HEAPLESS_SIZE>(&note_key[i], ciphertext)?;
+        let note = Note::try_from_slice(plain.as_slice()).ok()?;
 
         let note_hash = {
             let note_hash = &mut &note_hashes[i * num_size..(i + 1) * num_size];
@@ -257,7 +236,8 @@ fn _decrypt_in<P: PoolParams>(eta:Num<P::Fr>, mut memo:&[u8], params:&P)->Option
         };
 
         let ciphertext = buf_take(&mut memo, note_size+constants::POLY_1305_TAG_SIZE)?;
-        let note = decrypt_note::<P>(&key, ciphertext)?;
+        let plain = symcipher_decode::<NOTE_HEAPLESS_SIZE>(&key, ciphertext)?;
+        let note = Note::try_from_slice(plain.as_slice()).ok()?;
 
         let note_hash = {
             let note_hash = &mut &note_hashes[i * num_size..(i + 1) * num_size];

--- a/src/native/cipher.rs
+++ b/src/native/cipher.rs
@@ -196,7 +196,12 @@ fn _decrypt_in<P: PoolParams>(eta:Num<P::Fr>, mut memo:&[u8], params:&P)->Option
     let note = (0..nozero_notes_num).map(|i| {
         let a_pub = EdwardsPoint::subgroup_decompress(Num::deserialize(&mut memo).ok()?, params.jubjub())?;
         let ecdh = a_pub.mul(eta.to_other_reduced(), params.jubjub());
-        let key = keccak256(&ecdh.x.try_to_vec().unwrap());
+        
+        let key = {
+            let mut x: [u8; 32] = [0; 32];
+            ecdh.x.serialize(&mut &mut x[..]).unwrap();
+            keccak256(&x)
+        };
 
         let ciphertext = buf_take(&mut memo, note_size+constants::POLY_1305_TAG_SIZE)?;
         let text = symcipher_decode(&key, ciphertext)?;


### PR DESCRIPTION
This PR tries to reduce the number of runtime memory allocations during state syncing. The following was done:
1. Note, account, and shared secret decryption can now be executed in place if the preallocated buffer size is enough.
3. ecdh.x serialization doesn't allocate anything anymore.
4. Note hashes deserialization occurs only when it is necessary.

There are still a lot of allocations in try_from_slice and rayon but it isn't something that could be easily fixed. There is some PR: https://github.com/near/borsh-rs/pull/115 that tries to implement heapless deserialization but it's not ready yet.