### PR TITLE
Multicore wasm https

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ cli_libzeropool_setup = ["clap", "fawkes-crypto/rand_support", "fawkes-crypto/ba
 default=["cli_libzeropool_setup", "in3out127"]
 
 [dev-dependencies]
-fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm-https", version = "4.3.3", features = ["rand_support", "backend_bellman_groth16"] }
+fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm", version = "4.3.4", features = ["rand_support", "backend_bellman_groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "libzeropool-setup"
 required-features = ["cli_libzeropool_setup"] 
 
 [dependencies]
-fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.4", features = ["rand_support"] }
+fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm", version = "4.3.4", features = ["rand_support"] }
 
 sha3 = "0.9.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -36,4 +36,4 @@ cli_libzeropool_setup = ["clap", "fawkes-crypto/rand_support", "fawkes-crypto/ba
 default=["cli_libzeropool_setup", "in3out127"]
 
 [dev-dependencies]
-fawkes-crypto = { git = "ssh://git@github.com/zkBob/fawkes-crypto.git", branch = "multicore-wasm", version = "4.3.3", features = ["rand_support", "backend_bellman_groth16"] }
+fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm-https", version = "4.3.3", features = ["rand_support", "backend_bellman_groth16"] }


### PR DESCRIPTION
Replace `ssh` with `https` in `fawkes-crypto` dependency. `ssh` is not convenient for building images.