### PR TITLE
Add ability to decrypt memo with different ec points formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,13 @@ clap={ package = "clap-v3", version = "3.0.0-beta.1", optional=true}
 convert_case = "0.4.0"
 
 [dependencies.fawkes-crypto]
-git = "https://github.com/zkBob/fawkes-crypto"
-branch = "master"
 package = "fawkes-crypto-zkbob"
 version = "4.5.0"
 features = ["rand_support"]
 
 [dependencies.fawkes-crypto-keccak256]
 git = "https://github.com/zkbob/keccak"
-branch = "master"
+branch = "patch_test"
 package = "fawkes-crypto-zkbob-keccak256"
 version = "0.1.1"
 
@@ -49,8 +47,9 @@ cli_libzeropool_setup = ["clap", "fawkes-crypto/rand_support", "fawkes-crypto/ba
 default=["cli_libzeropool_setup", "in3out127"]
 
 [dev-dependencies.fawkes-crypto]
-git = "https://github.com/zkBob/fawkes-crypto"
-branch = "master"
 package = "fawkes-crypto-zkbob"
 version = "4.5.0"
 features = ["rand_support", "backend_bellman_groth16"]
+
+[patch.crates-io]
+fawkes-crypto-zkbob = {git = "https://github.com/zkBob/fawkes-crypto", branch = "feature/decompress_unchecked"}

--- a/src/native/ec_points.rs
+++ b/src/native/ec_points.rs
@@ -1,0 +1,84 @@
+use std::{convert::TryInto, str::FromStr};
+
+use fawkes_crypto::{ff_uint::Num, native::ecc::EdwardsPoint, BorshDeserialize};
+
+use super::{params::PoolParams, cipher::buf_take};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy, Default)]
+pub enum ECPointsFormat {
+    #[default]
+    XCoordinate,
+    XCoordinateWithSign,
+    XYCoordinates,
+}
+
+impl FromStr for ECPointsFormat {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<ECPointsFormat, Self::Err> {
+        match input {
+            "XCoordinate" => Ok(ECPointsFormat::XCoordinate),
+            "XCoordinateWithSign" => Ok(ECPointsFormat::XCoordinateWithSign),
+            "XYCoordinates" => Ok(ECPointsFormat::XYCoordinates),
+            _ => Err("unknown format".to_string()),
+        }
+    }
+}
+
+pub(crate) fn parse_ec_point<'a, P: PoolParams>(
+    memo: &mut &'a [u8],
+    num_size: usize,
+    params: &P,
+    ec_points_format: ECPointsFormat,
+) -> Option<EdwardsPoint<P::Fr>> {
+    match ec_points_format {
+        ECPointsFormat::XCoordinate => {
+            EdwardsPoint::subgroup_decompress(Num::deserialize(memo).ok()?, params.jubjub())
+        }
+        ECPointsFormat::XCoordinateWithSign => {
+            let bytes = buf_take(memo, num_size)?;
+            EdwardsPoint::decompress_unchecked(bytes.try_into().ok()?, params.jubjub())
+        }
+        ECPointsFormat::XYCoordinates => {
+            let point = EdwardsPoint {
+                x: Num::deserialize(memo).ok()?,
+                y: Num::deserialize(memo).ok()?,
+            };
+            if point.is_in_curve(params.jubjub()) {
+                Some(point)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+pub(crate) fn skip_ec_point<'a>(
+    memo: &mut &'a [u8],
+    num_size: usize,
+    ec_points_format: ECPointsFormat,
+) -> Option<()> {
+    match ec_points_format {
+        ECPointsFormat::XYCoordinates => {
+            buf_take(memo, num_size * 2)?;
+        }
+        _ => {
+            buf_take(memo, num_size)?;
+        }
+    }
+    Some(())
+}
+
+pub(crate) fn check_in_prime_subgroup<P: PoolParams>(
+    p: EdwardsPoint<P::Fr>,
+    params: &P,
+    ec_points_format: ECPointsFormat,
+) -> Option<()> {
+    match ec_points_format {
+        ECPointsFormat::XCoordinate => {
+            // we've already checked it in subgroup_decompress
+            Some(())
+        }
+        _ => p.is_in_prime_subgroup(params.jubjub()).then_some(()),
+    }
+}

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -7,6 +7,7 @@ pub mod cipher;
 pub mod key;
 pub mod tree;
 pub mod delegated_deposit;
+pub mod ec_points;
 
 mod borsh;
 mod sample;

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -17,18 +17,15 @@ fn test_encryption() {
     let sender_eta = rng.gen();
     let receiver_eta = rng.gen();
 
-
     let mut account: Account<Fr> = Account::sample(&mut rng, &*POOL_PARAMS);
     let mut note:Vec<Note<Fr>> = (0..2).map(|_| Note::sample(&mut rng, &*POOL_PARAMS)).collect();
-    
     
     account.p_d = derive_key_p_d(account.d.as_num().clone(), sender_eta, &*POOL_PARAMS).x;
     note[0].p_d = derive_key_p_d(note[0].d.as_num().clone(), receiver_eta, &*POOL_PARAMS).x;
     
-
     let ciphertext = cipher::encrypt(&(0..32).map(|_| rng.gen()).collect::<Vec<_>>(), sender_eta, account, &note, &*POOL_PARAMS);
 
-    let result_out = cipher::decrypt_out(sender_eta, &ciphertext, &*POOL_PARAMS, true);
+    let result_out = cipher::decrypt_out(sender_eta, &ciphertext, &*POOL_PARAMS, Default::default());
 
     assert!(result_out.is_some(), "Could not decrypt outgoing data.");
         let (account_out, note_out) = result_out.unwrap();
@@ -37,9 +34,7 @@ fn test_encryption() {
         account == account_out, "Wrong outgoing data decrypted");
 
 
-    let result_out = cipher::decrypt_in(receiver_eta, &ciphertext, &*POOL_PARAMS, true);
+    let result_out = cipher::decrypt_in(receiver_eta, &ciphertext, &*POOL_PARAMS, Default::default());
 
     assert!(result_out.len()==2 && result_out[0].is_some() && result_out[0].unwrap()==note[0] && result_out[1].is_none(), "Wrong incoming data decrypted");
-
-
 }

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -28,7 +28,7 @@ fn test_encryption() {
 
     let ciphertext = cipher::encrypt(&(0..32).map(|_| rng.gen()).collect::<Vec<_>>(), sender_eta, account, &note, &*POOL_PARAMS);
 
-    let result_out = cipher::decrypt_out(sender_eta, &ciphertext, &*POOL_PARAMS);
+    let result_out = cipher::decrypt_out(sender_eta, &ciphertext, &*POOL_PARAMS, true);
 
     assert!(result_out.is_some(), "Could not decrypt outgoing data.");
         let (account_out, note_out) = result_out.unwrap();
@@ -37,7 +37,7 @@ fn test_encryption() {
         account == account_out, "Wrong outgoing data decrypted");
 
 
-    let result_out = cipher::decrypt_in(receiver_eta, &ciphertext, &*POOL_PARAMS);
+    let result_out = cipher::decrypt_in(receiver_eta, &ciphertext, &*POOL_PARAMS, true);
 
     assert!(result_out.len()==2 && result_out[0].is_some() && result_out[0].unwrap()==note[0] && result_out[1].is_none(), "Wrong incoming data decrypted");
 


### PR DESCRIPTION
In this PR the following was done:
1. Added `ECPointsFormat` with possible values: `XCoordinate`, `XCoordinateWithSign`, and `XYCoordinates`.
2. Added ability to parse ec points of different formats
3. The check that the point is in the prime subgroup was moved after the decryption attempt.

The crucial statements that should be verified are that we still check that parsed points are on the curve and that they are in the prime subgroup regardless of ec points format. `subgroup_decompress` implicitly checks both statements. `decompress_unchecked` implicitly checks only the first one. `check_in_prime_subgroup` explicitly checks second statement after the decryption attempt.

The reason why it could be useful is described at https://github.com/zkBob/zkbob-pool-storage/issues/2.