### PR TITLE
Refactor message prefix, support batch affine addition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzeropool-zkbob"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Igor Gulamov <igor.gulamov@gmail.com>"]
 homepage = "https://github.com/zkbob/libzeropool"
 repository = "https://github.com/zkbob/libzeropool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzeropool-zkbob"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Igor Gulamov <igor.gulamov@gmail.com>"]
 homepage = "https://github.com/zkbob/libzeropool"
 repository = "https://github.com/zkbob/libzeropool"
@@ -31,7 +31,7 @@ convert_case = "0.4.0"
 git = "https://github.com/zkBob/fawkes-crypto"
 branch = "master"
 package = "fawkes-crypto-zkbob"
-version = "4.6.0"
+version = "4.7.0"
 features = ["rand_support"]
 
 [dependencies.fawkes-crypto-keccak256]
@@ -55,5 +55,5 @@ test-case = "2.2.2"
 git = "https://github.com/zkBob/fawkes-crypto"
 branch = "master"
 package = "fawkes-crypto-zkbob"
-version = "4.6.0"
+version = "4.7.0"
 features = ["rand_support", "backend_bellman_groth16"]

--- a/src/native/cipher.rs
+++ b/src/native/cipher.rs
@@ -17,7 +17,7 @@ use crate::{
 use super::symmetric::{encrypt_chacha_constant_nonce, keccak256, decrypt_chacha_constant_nonce, Buffer, encrypt_xchacha, decrypt_xchacha};
 
 #[derive(Debug)]
-pub struct UnsupportedMemoVesion;
+pub struct UnsupportedEncryption;
 
 /// The memo message encryption scheme
 pub enum MessageEncryptionType {
@@ -38,12 +38,12 @@ impl MessageEncryptionType {
         }
     }
 
-    pub fn from_u16(enc_type: u16) -> Result<MessageEncryptionType, UnsupportedMemoVesion> {
+    pub fn from_u16(enc_type: u16) -> Result<MessageEncryptionType, UnsupportedEncryption> {
         match enc_type {
             0x0000 => Ok(Self::ECDH),
             0x0100 => Ok(Self::Plain),
             0x0200 => Ok(Self::Symmetric),
-            _ => Err(UnsupportedMemoVesion),
+            _ => Err(UnsupportedEncryption),
         }
     }
 }
@@ -354,8 +354,8 @@ pub fn decrypt_note_no_validate<P: PoolParams>(symkey: &[u8], ciphertext: &[u8],
     Note::try_from_slice(plain.as_slice()).ok()
 }
 
-/// Deprecated
-fn _encrypt_old<P: PoolParams>(
+/// Deprecated but still in use on the old pools
+pub fn _encrypt_old<P: PoolParams>(
     entropy: &[u8],
     eta:Num<P::Fr>,
     account: Account<P::Fr>,


### PR DESCRIPTION
- updated underlying libraries to support batch affine addition
- refactoring `Version` enum: now it's called `MessageEncryptionType`
- deprecated ECDH encryption become available to support old pools
- symmetric encryption prefix was changed: `0x0001` - > `0x0200`